### PR TITLE
Fix reading of clock name

### DIFF
--- a/pytsdl/parser.py
+++ b/pytsdl/parser.py
@@ -1494,7 +1494,7 @@ class _DocCreatorVisitor:
         clock = self._get_cur_obj()
 
         if key == 'name':
-            clock.name = value[0].value
+            clock.name = value.value
         elif key == 'description':
             clock.description = value.value
         elif key == 'freq':


### PR DESCRIPTION
While trying to read a document with a clock, I get the following error:

  ...
  File ".../pytsdl/parser.py", line 1497, in _value_assign_clock
    clock.name = value[0].value
  TypeError: 'LiteralString' object does not support indexing

Removing the [0] seems to work.

Fixes #2
